### PR TITLE
Fix reference to @mcalligator's GH identity

### DIFF
--- a/src/topics/news_2022-08-30.md
+++ b/src/topics/news_2022-08-30.md
@@ -7,7 +7,7 @@ patterns:
   - 'Javascript'
 summary: m-ld expanding, public event, federating systems, and security!
 author:
-  git: Angus-McAllister
+  git: mcalligator
   name: Angus
 date: 2022-09-06
 linkedin: m-ld-io_news-activity-6975412303856812033--VEC


### PR DESCRIPTION
@mcalligator's GitHub username was incorrect on [a news post](https://m-ld.org/news/#news_2022-08-30), causing a broken image and a broken author link.

![CleanShot 2023-01-31 at 14 04 22@2x](https://user-images.githubusercontent.com/2407/215857821-76bc3ad3-87bc-4205-8b64-344fa7d60511.png)

[Fixed preview version](https://m-ld-website-git-fix-mcalligator-gsvarovsky.vercel.app/news/#news_2022-08-30)

<img width="398" alt="CleanShot 2023-01-31 at 14 07 47@2x" src="https://user-images.githubusercontent.com/2407/215858227-536dbc1b-461e-4dc1-8e8b-d606c17e29e4.png">
