### PR TITLE
Update to security (and other) docs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "dependencies": {
         "@ably/msgpack-js": "^0.4.0",
         "@m-ld/io-web-runtime": "^0.2.2",
-        "@m-ld/m-ld": "^0.9.1-edge.0",
+        "@m-ld/m-ld": "^0.9.1",
         "@types/d3": "^5.16.4",
         "@types/file-saver": "^2.0.4",
         "@types/jsoneditor": "^8.6.0",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "link-locals": "npm link ../m-ld-js ../m-ld-io-web-base/build ../m-ld-io-web-base/runtime",
     "clean": "rm -rf _site",
     "build": "npx eleventy",
-    "local": "now dev"
+    "local": "vercel dev"
   },
   "repository": {
     "type": "git",
@@ -27,7 +27,7 @@
   "dependencies": {
     "@ably/msgpack-js": "^0.4.0",
     "@m-ld/io-web-runtime": "^0.2.2",
-    "@m-ld/m-ld": "^0.9.1-edge.0",
+    "@m-ld/m-ld": "^0.9.1",
     "@types/d3": "^5.16.4",
     "@types/file-saver": "^2.0.4",
     "@types/jsoneditor": "^8.6.0",

--- a/src/_includes/sidebar.liquid
+++ b/src/_includes/sidebar.liquid
@@ -15,6 +15,7 @@
     <li><a href="/doc/#structured-data">Structured Data</a></li>
     <li><a href="/doc/#realtime">Realtime</a></li>
     <li><a href="/doc/#concurrency">Concurrency</a></li>
+    <li><a href="/doc/#extensibility">Extensibility</a></li>
     <li><a href="/doc/#multi-platform">Multi-Platform</a></li>
     <li><a href="/doc/#security">Security</a></li>
   </ul>

--- a/src/topics/doc/concurrency.md
+++ b/src/topics/doc/concurrency.md
@@ -2,6 +2,7 @@
 tags:
   - topic # mandatory
   - doc # 1th tag is page
+  - principle
 title: Concurrency
 patterns:
   - concurrency
@@ -43,7 +44,7 @@ like:
 - This property refers to some other entity which exists
 
 In a programming language, you might find these rules expressed in the type
-system. In a relational database, the rules are called "constraints".
+system. In a relational database, the rules are the schema and constraints.
 
 In **m-ld**, integrity is a collaboration between the domain, engine, app and
 user. **m-ld** supports constraints (see below), but first it is important to
@@ -77,7 +78,7 @@ the following categories:
   for example in the next user workflow step, or even by a housekeeping process
   which applies a procedural fix.
 - *Procedure*. A conflict may manifest as a nonsensical or ambiguous state for
-  which it is possible to automaticaly make a correction or decide an outcome.
+  which it is possible to automatically make a correction or decide an outcome.
   The correction can be implemented in the app code. However, since each app
   instance may at any time 'see' a different state, these corrections can
   potentially compete with each other, so care must be taken not to create a
@@ -89,13 +90,18 @@ the following categories:
   to the domain via any clone using a normal transaction.
 
 ### Constraints
-The **m-ld** [specification](http://spec.m-ld.org/#data-semantics) defines a set
-of declarative constraints that can be applied to a domain. Unlike app-based
-integrity rules, these do not require that the app recognise and handle rule
-violations – the app is able to rely on the data it perceives always being
-compliant with the rule.
+A **m-ld** domain can be configured with _constraints_, which are rules that apply to both local and remote transactions. Unlike app-based integrity rules, these do not require that the app recognise and handle rule violations – the app is able to rely on the data it perceives always being compliant with the rule.
 
-> 🚧 Inclusion of declarative integrity constraints in **m-ld** is an
-> experimental feature, and the subject of active research. The available
-> constraints and the means by which they are declared for a domain is likely to
-> change. Please do [contact&nbsp;us](/hello/) with your requirements.
+Constraints are an [extension](/doc/#extensibility) point, allowing apps to choose a pre-existing implementation or to create their own. The implementation of constraints may require handling of concurrency edge-cases to ensure that convergence is still guaranteed.
+
+Consult the [platform engine](/doc/#platforms) documentation for details on the available constraints and how to configure them.
+
+### Agreements
+Some state changes in a distributed system require the _agreement_ of system participants. This is associated with the potential for a user, who is somehow unaware of the agreement (for example, by being offline), to have their changes declared _void_ – that is, entirely revoked. For example:
+
+- Changes concurrent with a data schema change – the state may no longer be compatible with the schema
+- Changes concurrent with access control changes – the concurrent change might not be allowed
+
+An _agreement_ is a coordinated change of state, as distinct from an inherently uncoordinated conflict-free change. An agreement is binding on all participants, but its coordination may involve any subset of them, such as a majority consensus, or even just one participant who has the "authority" to unilaterally agree.
+
+> 🚧 Agreements support in **m-ld** is currently experimental. You can read the [white paper here](https://github.com/m-ld/m-ld-security-spec/blob/main/design/suac.md), and explore the [prototype support](https://js.m-ld.org/interfaces/agreementcondition.html) in the Javascript engine. Please [contact us](/hello/) to discuss your integrity requirements.

--- a/src/topics/doc/concurrency.md
+++ b/src/topics/doc/concurrency.md
@@ -90,18 +90,30 @@ the following categories:
   to the domain via any clone using a normal transaction.
 
 ### Constraints
-A **m-ld** domain can be configured with _constraints_, which are rules that apply to both local and remote transactions. Unlike app-based integrity rules, these do not require that the app recognise and handle rule violations – the app is able to rely on the data it perceives always being compliant with the rule.
+A **m-ld** domain can be configured with _constraints_, which are rules that apply to both local and remote transactions. Unlike app-based integrity rules, these do not require that the app recognise and handle rule violations – the app is able to rely on the data it perceives always being compliant with the rule. For example:
+
+- The value of a property always has a specific type, like a number or a string
+- The value of a property always has exactly one value
+
+Constraints can also be used to describe and enforce arbitrarily complex rules on transactions, for example:
+
+- Some data must only be changed by someone authorised (see [security](/doc/#security)), or by consensus
+- Certain inputs are normalised to other structures before being committed to the data
+- Additional data is inferred from input data
 
 Constraints are an [extension](/doc/#extensibility) point, allowing apps to choose a pre-existing implementation or to create their own. The implementation of constraints may require handling of concurrency edge-cases to ensure that convergence is still guaranteed.
 
-Consult the [platform engine](/doc/#platforms) documentation for details on the available constraints and how to configure them.
+For details of the available constraints and how to configure them, consult the engine documentation for the [platform](/doc/#platforms) you are using.
 
 ### Agreements
 Some state changes in a distributed system require the _agreement_ of system participants. This is associated with the potential for a user, who is somehow unaware of the agreement (for example, by being offline), to have their changes declared _void_ – that is, entirely revoked. For example:
 
-- Changes concurrent with a data schema change – the state may no longer be compatible with the schema
-- Changes concurrent with access control changes – the concurrent change might not be allowed
+- Changes concurrent with a data schema change – the changed state may not be compatible with the new schema
+- Changes concurrent with access control changes – the concurrent change might not be have been allowed
 
-An _agreement_ is a coordinated change of state, as distinct from an inherently uncoordinated conflict-free change. An agreement is binding on all participants, but its coordination may involve any subset of them, such as a majority consensus, or even just one participant who has the "authority" to unilaterally agree.
+An _agreement_ is a coordinated change of state, as distinct from an inherently uncoordinated conflict-free change. An agreement is binding on all participants, but its coordination may involve any subset of them. Examples of coordination schemes include:
+- consensus algorithms like Paxos or Raft
+- decentralised consensus mechanisms like proof-of-stake
+- unilateral agreement by one participant who has "authority"
 
 > 🚧 Agreements support in **m-ld** is currently experimental. You can read the [white paper here](https://github.com/m-ld/m-ld-security-spec/blob/main/design/suac.md), and explore the [prototype support](https://js.m-ld.org/interfaces/agreementcondition.html) in the Javascript engine. Please [contact us](/hello/) to discuss your integrity requirements.

--- a/src/topics/doc/extensibility.md
+++ b/src/topics/doc/extensibility.md
@@ -18,7 +18,7 @@ Some extensions must be pre-selected by the app in order to connect a new clone 
 **m-ld** defines a number of extension points:
 - [Messaging](/doc/#messaging) is usually pre-selected by the app.
 - Constraints (see above) define integrity rules on the domain's data.
-- Transport Security allows an app to encrypt and apply digital signatures to **m-ld** protocol network traffic.
+- Transport Security allows an app to protect **m-ld** network traffic by encrypting and/or digitally signing it.
 - Agreement Conditions assert necessary preconditions for an [agreement](/doc/#agreements).
 
 > 🚧 Transport Security and Agreement Conditions are currently experimental. You can read the [white paper here](https://github.com/m-ld/m-ld-security-spec/blob/main/design/suac.md), and explore the [prototype support](https://js.m-ld.org/#extensions) in the Javascript engine. Please [contact us](/hello/) to discuss your requirements.

--- a/src/topics/doc/extensibility.md
+++ b/src/topics/doc/extensibility.md
@@ -1,0 +1,24 @@
+---
+tags:
+  - topic # mandatory
+  - doc # 1th tag is page
+  - principle
+title: Extensibility
+patterns:
+  - extension extensibility
+summary: '<b>m-ld</b> behaviour is extensible in principle.'
+date: 2020-06-15 # Used for sort order
+---
+**m-ld** is designed for [_Decentralised Extensibility_](https://bit.ly/realtime-rdf-paper). This is a property of systems that permit and support any interested party to develop an extension, and new extensions can be added without permission from a central authority.
+
+You can choose which extensions to use in an app; some may be bundled in a [platform engine](/doc/#platforms) package, others you can write yourself.
+
+Some extensions must be pre-selected by the app in order to connect a new clone to a domain of information. Other extensions can be declared in the data and loaded dynamically by the engine. This allows apps to adapt their behaviour at runtime.
+
+**m-ld** defines a number of extension points:
+- [Messaging](/doc/#messaging) is usually pre-selected by the app.
+- Constraints (see above) define integrity rules on the domain's data.
+- Transport Security allows an app to encrypt and apply digital signatures to **m-ld** protocol network traffic.
+- Agreement Conditions assert necessary preconditions for an [agreement](/doc/#agreements).
+
+> 🚧 Transport Security and Agreement Conditions are currently experimental. You can read the [white paper here](https://github.com/m-ld/m-ld-security-spec/blob/main/design/suac.md), and explore the [prototype support](https://js.m-ld.org/#extensions) in the Javascript engine. Please [contact us](/hello/) to discuss your requirements.

--- a/src/topics/doc/security.md
+++ b/src/topics/doc/security.md
@@ -44,7 +44,7 @@ Fine-grained write access control within a single domain can be achieved using _
 > 🚧 Using constraints for fine-grained write access control is currently experimental. You can read the [white paper here](https://github.com/m-ld/m-ld-security-spec/blob/main/design/suac.md), and explore the [prototype support](https://js.m-ld.org/classes/writepermitted.html) in the Javascript engine. Please [contact us](/hello/) to discuss your security requirements.
 
 ### Auditing & Non-Repudiation
-Once a user is authorised to the application, it may be important to record their activity, as well as that of any other system actor such as a bot, in tamper-proof way, for later auditing. In common with other systems, it is usually most efficient to use a dedicated system component for this. In an app using **m-ld**, a clone of the data can be located with the audit logging component.
+Once a user is authorised to the application, it may be important to record their activity, as well as that of any other system actor such as a bot, in a tamper-proof way, for later auditing. In common with other systems, it is usually most efficient to use a dedicated system component for this. In an app using **m-ld**, a clone of the data can be located with the audit logging component.
 
 It is possible to use the Transport Security [extension](/doc/#extensibility) point to provide assurance of user identity to the audit logging system, by means of digital signatures.
 

--- a/src/topics/doc/security.md
+++ b/src/topics/doc/security.md
@@ -15,11 +15,7 @@ collaboration with the app implementation, since the app must be allowed
 privileged access to the data in order to function.
 
 ### Threats
-The threats that must be controlled in collaboration with a clone engine are a
-subset of the threats to the app. These include threats to:
-- *Confidentiality*: reading of data to steal information
-- *Integrity*: modification of data to mislead information consumers
-- *Availability*: prevention of normal function for sabotage or coercion
+The threats that must be controlled in collaboration with a clone engine are a subset of the threats to the app. These include threats to *Confidentiality*, *Integrity* and *Availability*.
 
 The attack surface of an engine generally comprises:
 - The local device storage being used by the engine
@@ -27,56 +23,28 @@ The attack surface of an engine generally comprises:
 - The clone API presented to the app
 
 ### Trust Model
-A decentralised data store does not have a privileged, trusted central authority
-(although the trust model of such a central authority may never have been as
-straightforward as it seemed, as evidenced by damaging data leakages by such
-authorities). Since an app must be free to decide its own security model, and
-since the **m-ld** engine is not itself afforded any special privilege because
-of its deployment, an engine *trusts the app* in principle. The consequences of
-this are explained in the sections below.
+An app using **m-ld** is free to decide its own security model. Because the **m-ld** engine is embedded in the app, it not itself afforded any special privilege because of its deployment. In particular, a **m-ld** domain does not inherently have a privileged, trusted central authority. However, an app may choose to deploy **m-ld** clones to its own trusted service or data tier.
 
-### Authentication & Authorisation
-It is the app's responsibility to authenticate and authorise its users. For the
-reason above, and unlike some centralised data management systems, **m-ld** does
-not have a first-class 'user' concept with special semantics. This includes any
-notion of credentials, such as passwords. (Note that this does not prevent an
-app from storing user information in **m-ld**, so long as it uses suitable access
-controls.)
+### Authentication
+It is the app's responsibility to authenticate its users by any chosen means, such as device-native login, or using a third-party single sign-on system. The app should gate access, using the authentication, to its functions which access the **m-ld** engine.
 
-This means an app is free to authenticate its users by any chosen means, such as
-device-native login, or using a third-party single sign-on system. The app
-should gate access, using the authentication, to its functions which access the
-**m-ld** engine.
+Data is transmitted between clones using a choice of [messaging](/doc/#messaging) provider. Since this data is at risk from network attacks, the messaging system itself should be authenticated, either with the user credentials or some token obtained with them.
 
-> 🚧 In future, **m-ld** will allow an app to negotiate a 'local key' credential
-> that the engine can use to:
-> - confirm the identity of the app instance, for example after a re-start
-> - selectively encrypt data in storage and on the network (see below)
-> - identify and suppress malware (see below)
->
-> A specification document for future security features will shortly be
-> available in this portal. Please [feed-back](/hello/) any specific concerns
-> you have.
+An example app login behaviour:
+1. Redirect the user to login via an identity provider
+2. Retrieve a signed token from identity provider
+3. Connect to the messaging system using the token
+4. Initialise the **m-ld** clone with the messaging system connection
+
+### Authorisation
+In many apps, authenticated users will have read/write access to the domain as a whole. The app controls which domains the user can select from and connect a clone to. To prevent unauthorised access to data-in-transit from other domains, it is generally necessary to control access to the _channels_ of the messaging system in use.
+
+Fine-grained write access control within a single domain can be achieved using _constraints_.
+
+> 🚧 Using constraints for fine-grained write access control is currently experimental. You can read the [white paper here](https://github.com/m-ld/m-ld-security-spec/blob/main/design/suac.md), and explore the [prototype support](https://js.m-ld.org/classes/writepermitted.html) in the Javascript engine. Please [contact us](/hello/) to discuss your security requirements.
 
 ### Auditing & Non-Repudiation
-Once a user is authorised to the application, it may be important to record
-their activity, as well as that of any other system actor such as a bot, in
-tamper-proof way, for later auditing. This can generally be achieved with the
-use of audit stamps (time & user) on updates. If necessary, these stamps could
-be digitally signed by the app.
-
-Clones maintain a 'journal' of updates, so audit data of this kind is
-effectively distributed in the domain. However, the journal is subject to
-truncation based on a clone-internal strategy for managing storage. To ensure
-long-term archival, an app-specific strategy can be adopted to stream update
-events to some other storage.
-
-> 🚧 The clone journal is currently an internal feature with no API access.
-> Continuous updates are available via the `follow` API.
-> 
-> Furthermore, **m-ld** has been designed from the outset to be able to
-> *natively* track app/user activity in a cryptographically-verifiable way.
-> Details will be included in the forthcoming security specification.
+Once a user is authorised to the application, it may be important to record their activity, as well as that of any other system actor such as a bot, in tamper-proof way, for later auditing. This can generally be achieved with the use of audit stamps (time & user) on updates. If necessary, these stamps can be digitally signed by the app.
 
 ### Storage & Network
 A **m-ld** engine may use storage to automatically persist data between and
@@ -103,18 +71,6 @@ Typical app controls will include encryption of data at rest and on the wire.
 This has the advantage that it prevents unauthorised access and tampering by any
 device without credentials.
 
-> 🚧 The app's ownership of storage and network handles could be combined with
-> its authentication mechanism to control access *per user*. For example, a
-> local user not being authorised to see some data belonging to another user.
-> However, this approach requires the app to have knowledge of the engine's
-> storage data format, and the **m-ld** protocol's data format. These may not be
-> easy to manipulate. It also requires the app instance to have privileges above
-> that of the local user. On some devices this may not be possible.
->
-> We are working on an entension to the **m-ld** protocol that will support
-> automatic application of selective data encryption. Details will be included
-> in the forthcoming security specification.
-
 ### Malware
 In common with other decentralised technologies, in principle **m-ld** has no
 central data gatekeeper with a controlled implementation.
@@ -130,12 +86,3 @@ privileged access to domain data, both for read and write.
 
 It is therefore critical that the app is protected from malware at the level of
 the compute platform.
-
-> 🚧 This vulnerability can arise in distributed computing of any kind (except
-> in a trusted compute platform, and that has problems of its own). But once it
-> has arisen, identifying and suppressing malware requires coordination among
-> the peers of a decentralised system.
->
-> We are working on an entension to the **m-ld** protocol that will support
-> early identification and suppression of malware and suspicious activity.
-> Details will be included in the forthcoming security specification.

--- a/src/topics/doc/security.md
+++ b/src/topics/doc/security.md
@@ -23,10 +23,10 @@ The attack surface of an engine generally comprises:
 - The clone API presented to the app
 
 ### Trust Model
-An app using **m-ld** is free to decide its own security model. Because the **m-ld** engine is embedded in the app, it not itself afforded any special privilege because of its deployment. In particular, a **m-ld** domain does not inherently have a privileged, trusted central authority. However, an app may choose to deploy **m-ld** clones to its own trusted service or data tier.
+An app using **m-ld** is free to decide its own security model. Because the **m-ld** engine is embedded in the app, it does not have any special privilege because of its deployment. In particular, a **m-ld** domain does not inherently have any privileged, trusted central authority. However, an app may choose to deploy **m-ld** clones to its own trusted service or data tier.
 
 ### Authentication
-It is the app's responsibility to authenticate its users by any chosen means, such as device-native login, or using a third-party single sign-on system. The app should gate access, using the authentication, to its functions which access the **m-ld** engine.
+It is the app's responsibility to authenticate its users by any chosen method, such as device-native login, or using a third-party single sign-on system, in order to gate access to its functions which access the **m-ld** engine.
 
 Data is transmitted between clones using a choice of [messaging](/doc/#messaging) provider. Since this data is at risk from network attacks, the messaging system itself should be authenticated, either with the user credentials or some token obtained with them.
 
@@ -44,7 +44,9 @@ Fine-grained write access control within a single domain can be achieved using _
 > 🚧 Using constraints for fine-grained write access control is currently experimental. You can read the [white paper here](https://github.com/m-ld/m-ld-security-spec/blob/main/design/suac.md), and explore the [prototype support](https://js.m-ld.org/classes/writepermitted.html) in the Javascript engine. Please [contact us](/hello/) to discuss your security requirements.
 
 ### Auditing & Non-Repudiation
-Once a user is authorised to the application, it may be important to record their activity, as well as that of any other system actor such as a bot, in tamper-proof way, for later auditing. This can generally be achieved with the use of audit stamps (time & user) on updates. If necessary, these stamps can be digitally signed by the app.
+Once a user is authorised to the application, it may be important to record their activity, as well as that of any other system actor such as a bot, in tamper-proof way, for later auditing. In common with other systems, it is usually most efficient to use a dedicated system component for this. In an app using **m-ld**, a clone of the data can be located with the audit logging component.
+
+It is possible to use the Transport Security [extension](/doc/#extensibility) point to provide assurance of user identity to the audit logging system, by means of digital signatures.
 
 ### Storage & Network
 A **m-ld** engine may use storage to automatically persist data between and


### PR DESCRIPTION
m-ld/m-ld-security-spec#5: Update to security (and other) docs post security project.

Adjustments are for accuracy, including warnings for experimental features.

Also added missing extensibility section.

I've decided not to update `spec.m-ld.org` with the new agreements concept, because it would just duplicate what's in the JS repo (and marked as Experimental). Better to wait for the launch docs overhaul.